### PR TITLE
UI optimization: mobile nav, shared components, sticky header

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -42,13 +44,7 @@ export default function AboutPage() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'FAQ', href: '/en/faq' },
-            { label: 'Glossary', href: '/en/glossary' },
-            { label: 'Compare', href: '/en/compare' },
-          ]}
+          navItems={getNavItems('en', '/about')}
           langSwitchHref="/about/"
         />
 
@@ -118,13 +114,7 @@ export default function AboutPage() {
           </p>
         </section>
 
-        <footer style={{ textAlign: 'center', marginTop: '48px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <div style={{ display: 'flex', justifyContent: 'center', gap: '16px', fontSize: '14px' }}>
-            <Link href="/" style={{ color: '#2563eb', textDecoration: 'none' }}>Home</Link>
-            <Link href="/en/blog" style={{ color: '#2563eb', textDecoration: 'none' }}>Blog</Link>
-            <Link href="/newsletter" style={{ color: '#2563eb', textDecoration: 'none' }}>Newsletter</Link>
-          </div>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/compare/[slug]/page.tsx
+++ b/src/app/en/compare/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { getAllCompares, getCompare, generateCompareJsonLd } from '@/lib/compare'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import type { Metadata } from 'next'
 
 interface Props {
@@ -64,13 +66,7 @@ export default async function CompareDetailPageEn({ params }: Props) {
 
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'FAQ', href: '/en/faq' },
-            { label: 'Glossary', href: '/en/glossary' },
-            { label: 'Compare', href: '/en/compare', active: true },
-          ]}
+          navItems={getNavItems('en', '/en/compare')}
           langSwitchHref={`/zh/compare/${zhSlug}`}
         />
 
@@ -102,6 +98,7 @@ export default async function CompareDetailPageEn({ params }: Props) {
             ))}
           </div>
         )}
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/compare/page.tsx
+++ b/src/app/en/compare/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getAllCompares } from '@/lib/compare'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 export const metadata = {
   title: 'Compare AI Models | LoreAI',
@@ -21,13 +23,7 @@ export default function ComparePageEn() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'FAQ', href: '/en/faq' },
-            { label: 'Glossary', href: '/en/glossary' },
-            { label: 'Compare', href: '/en/compare', active: true },
-          ]}
+          navItems={getNavItems('en', '/en/compare')}
           langSwitchHref="/zh/compare"
         />
 
@@ -60,10 +56,7 @@ export default function ComparePageEn() {
           </div>
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>Curated by AI · Built for humans</p>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/faq/[topic]/[question]/page.tsx
+++ b/src/app/en/faq/[topic]/[question]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { getAllQuestionParams, getQuestion, getRelatedQuestions, generateQuestionJsonLd } from '@/lib/faq'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import type { Metadata } from 'next'
 
 interface Props {
@@ -54,13 +56,7 @@ export default async function FAQQuestionPageEn({ params }: Props) {
 
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'FAQ', href: '/en/faq', active: true },
-            { label: 'Glossary', href: '/en/glossary' },
-            { label: 'Compare', href: '/en/compare' },
-          ]}
+          navItems={getNavItems('en', '/en/faq')}
           langSwitchHref={`/zh/faq/${zhTopicSlug}/${questionSlug}`}
         />
 
@@ -93,6 +89,7 @@ export default async function FAQQuestionPageEn({ params }: Props) {
             ))}
           </div>
         )}
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/faq/[topic]/page.tsx
+++ b/src/app/en/faq/[topic]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { getAllFAQTopics, getFAQTopic, generateFAQJsonLd } from '@/lib/faq'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import type { FAQIntent } from '@/lib/faq'
 import type { Metadata } from 'next'
 
@@ -78,13 +80,7 @@ export default async function FAQTopicPageEn({ params }: Props) {
 
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'FAQ', href: '/en/faq', active: true },
-            { label: 'Glossary', href: '/en/glossary' },
-            { label: 'Compare', href: '/en/compare' },
-          ]}
+          navItems={getNavItems('en', '/en/faq')}
           langSwitchHref={`/zh/faq/${zhSlug}`}
         />
 
@@ -124,6 +120,7 @@ export default async function FAQTopicPageEn({ params }: Props) {
             </section>
           )
         })}
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/faq/page.tsx
+++ b/src/app/en/faq/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getAllFAQTopics } from '@/lib/faq'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 export const metadata = {
   title: 'FAQ | LoreAI',
@@ -21,13 +23,7 @@ export default function FAQPageEn() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'FAQ', href: '/en/faq', active: true },
-            { label: 'Glossary', href: '/en/glossary' },
-            { label: 'Compare', href: '/en/compare' },
-          ]}
+          navItems={getNavItems('en', '/en/faq')}
           langSwitchHref="/zh/faq"
         />
 
@@ -60,10 +56,7 @@ export default function FAQPageEn() {
           </div>
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>Curated by AI · Built for humans</p>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/glossary/[term]/page.tsx
+++ b/src/app/en/glossary/[term]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { getGlossaryTerms, getGlossaryTerm, generateGlossaryJsonLd } from '@/lib/glossary'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import type { Metadata } from 'next'
 
 interface Props {
@@ -60,13 +62,7 @@ export default async function GlossaryTermPageEn({ params }: Props) {
 
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'FAQ', href: '/en/faq' },
-            { label: 'Glossary', href: '/en/glossary', active: true },
-            { label: 'Compare', href: '/en/compare' },
-          ]}
+          navItems={getNavItems('en', '/en/glossary')}
           langSwitchHref={`/zh/glossary/${slug}`}
         />
 
@@ -102,6 +98,7 @@ export default async function GlossaryTermPageEn({ params }: Props) {
             ))}
           </div>
         )}
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/glossary/page.tsx
+++ b/src/app/en/glossary/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getGlossaryTerms } from '@/lib/glossary'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 export const metadata = {
   title: 'Glossary | LoreAI',
@@ -30,13 +32,7 @@ export default function GlossaryPageEn() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'FAQ', href: '/en/faq' },
-            { label: 'Glossary', href: '/en/glossary', active: true },
-            { label: 'Compare', href: '/en/compare' },
-          ]}
+          navItems={getNavItems('en', '/en/glossary')}
           langSwitchHref="/zh/glossary"
         />
 
@@ -82,10 +78,7 @@ export default function GlossaryPageEn() {
           ))
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>Curated by AI · Built for humans</p>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/resources/page.tsx
+++ b/src/app/en/resources/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getBlogPosts } from '@/lib/blog'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 function formatDate(dateStr: string): string {
   const date = new Date(dateStr + 'T00:00:00')
@@ -31,11 +33,7 @@ export default async function ResourcesPage() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'Resources', href: '/en/resources', active: true },
-          ]}
+          navItems={getNavItems('en', '/en/resources')}
           langSwitchHref="/zh/resources"
         />
 
@@ -118,10 +116,7 @@ export default async function ResourcesPage() {
           </Link>
         </div>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>Curated by AI · Built for humans</p>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/timeline/[topic]/page.tsx
+++ b/src/app/en/timeline/[topic]/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import { getAllTimelines, getTimeline, groupByDate, generateTimelineJsonLd } from '@/lib/timeline'
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
@@ -48,12 +50,7 @@ export default async function TimelineDetailEn({ params }: Props) {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'Topics', href: '/en/topics' },
-            { label: 'Timeline', href: '/en/timeline', active: true },
-          ]}
+          navItems={getNavItems('en', '/en/timeline')}
           langSwitchHref={`/zh/timeline/${topic}`}
         />
 
@@ -140,10 +137,7 @@ export default async function TimelineDetailEn({ params }: Props) {
           </Link>
         </div>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '48px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>Curated by AI · Built for humans</p>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/timeline/page.tsx
+++ b/src/app/en/timeline/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import { getAllTimelines } from '@/lib/timeline'
 
 export const metadata = {
@@ -21,12 +23,7 @@ export default function TimelineIndexEn() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'Topics', href: '/en/topics' },
-            { label: 'Timeline', href: '/en/timeline', active: true },
-          ]}
+          navItems={getNavItems('en', '/en/timeline')}
           langSwitchHref="/zh/timeline"
         />
 
@@ -73,10 +70,7 @@ export default function TimelineIndexEn() {
           </div>
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>Curated by AI · Built for humans</p>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/topics/[topic]/page.tsx
+++ b/src/app/en/topics/[topic]/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import { getTopicClusters, getTopicClusterContent } from '@/lib/topic-cluster'
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
@@ -84,11 +86,7 @@ export default async function TopicHubPageEn({ params }: Props) {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'Topics', href: '/en/topics', active: true },
-          ]}
+          navItems={getNavItems('en', '/en/topics')}
           langSwitchHref={`/zh/topics/${topic}`}
         />
 
@@ -190,10 +188,7 @@ export default async function TopicHubPageEn({ params }: Props) {
           </Link>
         </div>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '48px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>Curated by AI · Built for humans</p>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/en/topics/page.tsx
+++ b/src/app/en/topics/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import { getAllTopicClustersWithCounts } from '@/lib/topic-cluster'
 
 export const metadata = {
@@ -21,11 +23,7 @@ export default async function TopicsPageEn() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter' },
-            { label: 'Blog', href: '/en/blog' },
-            { label: 'Topics', href: '/en/topics', active: true },
-          ]}
+          navItems={getNavItems('en', '/en/topics')}
           langSwitchHref="/zh/topics"
         />
 
@@ -72,10 +70,7 @@ export default async function TopicsPageEn() {
           </div>
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>Curated by AI · Built for humans</p>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -386,10 +386,6 @@ a.link-blue:hover {
    ============================================ */
 
 .site-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 0;
   margin-bottom: 32px;
 }
 
@@ -453,8 +449,8 @@ a.link-blue:hover {
 
 .toc-sticky {
   position: sticky;
-  top: 6rem;
-  max-height: calc(100vh - 8rem);
+  top: 5rem;
+  max-height: calc(100vh - 6rem);
   overflow-y: auto;
 }
 

--- a/src/app/newsletter/[date]/page.tsx
+++ b/src/app/newsletter/[date]/page.tsx
@@ -5,6 +5,8 @@ import { notFound } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 async function getNewsletterContent(date: string): Promise<string | null> {
   try {
@@ -74,10 +76,7 @@ export default async function NewsletterDatePage({ params }: { params: Promise<{
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter', active: true },
-            { label: 'Blog', href: '/en/blog' },
-          ]}
+          navItems={getNavItems('en', '/newsletter')}
           langSwitchHref={langSwitchHref}
         />
 
@@ -208,15 +207,7 @@ export default async function NewsletterDatePage({ params }: { params: Promise<{
           </ReactMarkdown>
         </article>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '48px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <Link 
-            href="/newsletter"
-            style={{ color: '#8b5cf6', fontSize: '14px', textDecoration: 'none' }}
-          >
-            ← View all newsletters
-          </Link>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/newsletter/page.tsx
+++ b/src/app/newsletter/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link'
 import fs from 'fs'
 import path from 'path'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 interface NewsletterEntry {
   date: string
@@ -85,10 +87,7 @@ export default async function NewsletterPage() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="en"
-          navItems={[
-            { label: 'Newsletter', href: '/newsletter', active: true },
-            { label: 'Blog', href: '/en/blog' },
-          ]}
+          navItems={getNavItems('en', '/newsletter')}
           langSwitchHref="/zh/newsletter"
         />
 
@@ -243,12 +242,7 @@ export default async function NewsletterPage() {
           </form>
         </div>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '32px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>
-            Curated by AI · Updated daily
-          </p>
-        </footer>
+        <Footer lang="en" />
       </div>
     </main>
   )

--- a/src/app/zh/compare/[slug]/page.tsx
+++ b/src/app/zh/compare/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { getAllCompares, getCompare, generateCompareJsonLd } from '@/lib/compare'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import type { Metadata } from 'next'
 
 interface Props {
@@ -64,13 +66,7 @@ export default async function CompareDetailPageZh({ params }: Props) {
 
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '常见问题', href: '/zh/faq' },
-            { label: '术语表', href: '/zh/glossary' },
-            { label: '对比', href: '/zh/compare', active: true },
-          ]}
+          navItems={getNavItems('zh', '/zh/compare')}
           langSwitchHref={`/en/compare/${enSlug}`}
         />
 
@@ -102,6 +98,7 @@ export default async function CompareDetailPageZh({ params }: Props) {
             ))}
           </div>
         )}
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/compare/page.tsx
+++ b/src/app/zh/compare/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getAllCompares } from '@/lib/compare'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 export const metadata = {
   title: 'AI 模型对比 | LoreAI',
@@ -21,13 +23,7 @@ export default function ComparePageZh() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '常见问题', href: '/zh/faq' },
-            { label: '术语表', href: '/zh/glossary' },
-            { label: '对比', href: '/zh/compare', active: true },
-          ]}
+          navItems={getNavItems('zh', '/zh/compare')}
           langSwitchHref="/en/compare"
         />
 
@@ -60,10 +56,7 @@ export default function ComparePageZh() {
           </div>
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>AI 驱动 · 为人而建</p>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/faq/[topic]/[question]/page.tsx
+++ b/src/app/zh/faq/[topic]/[question]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { getAllQuestionParams, getQuestion, getRelatedQuestions, generateQuestionJsonLd } from '@/lib/faq'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import type { Metadata } from 'next'
 
 interface Props {
@@ -54,13 +56,7 @@ export default async function FAQQuestionPageZh({ params }: Props) {
 
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '常见问题', href: '/zh/faq', active: true },
-            { label: '术语表', href: '/zh/glossary' },
-            { label: '对比', href: '/zh/compare' },
-          ]}
+          navItems={getNavItems('zh', '/zh/faq')}
           langSwitchHref={`/en/faq/${enTopicSlug}/${questionSlug}`}
         />
 
@@ -92,6 +88,7 @@ export default async function FAQQuestionPageZh({ params }: Props) {
             ))}
           </div>
         )}
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/faq/[topic]/page.tsx
+++ b/src/app/zh/faq/[topic]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { getAllFAQTopics, getFAQTopic, generateFAQJsonLd } from '@/lib/faq'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import type { FAQIntent } from '@/lib/faq'
 import type { Metadata } from 'next'
 
@@ -77,13 +79,7 @@ export default async function FAQTopicPageZh({ params }: Props) {
 
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '常见问题', href: '/zh/faq', active: true },
-            { label: '术语表', href: '/zh/glossary' },
-            { label: '对比', href: '/zh/compare' },
-          ]}
+          navItems={getNavItems('zh', '/zh/faq')}
           langSwitchHref={`/en/faq/${enSlug}`}
         />
 
@@ -123,6 +119,7 @@ export default async function FAQTopicPageZh({ params }: Props) {
             </section>
           )
         })}
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/faq/page.tsx
+++ b/src/app/zh/faq/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getAllFAQTopics } from '@/lib/faq'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 export const metadata = {
   title: '常见问题 | LoreAI',
@@ -21,13 +23,7 @@ export default function FAQPageZh() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '常见问题', href: '/zh/faq', active: true },
-            { label: '术语表', href: '/zh/glossary' },
-            { label: '对比', href: '/zh/compare' },
-          ]}
+          navItems={getNavItems('zh', '/zh/faq')}
           langSwitchHref="/en/faq"
         />
 
@@ -60,10 +56,7 @@ export default function FAQPageZh() {
           </div>
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>AI 驱动 · 为人而建</p>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/glossary/[term]/page.tsx
+++ b/src/app/zh/glossary/[term]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { getGlossaryTerms, getGlossaryTerm, generateGlossaryJsonLd } from '@/lib/glossary'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import type { Metadata } from 'next'
 
 interface Props {
@@ -60,13 +62,7 @@ export default async function GlossaryTermPageZh({ params }: Props) {
 
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '常见问题', href: '/zh/faq' },
-            { label: '术语表', href: '/zh/glossary', active: true },
-            { label: '对比', href: '/zh/compare' },
-          ]}
+          navItems={getNavItems('zh', '/zh/glossary')}
           langSwitchHref={`/en/glossary/${slug}`}
         />
 
@@ -102,6 +98,7 @@ export default async function GlossaryTermPageZh({ params }: Props) {
             ))}
           </div>
         )}
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/glossary/page.tsx
+++ b/src/app/zh/glossary/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getGlossaryTerms } from '@/lib/glossary'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 export const metadata = {
   title: '术语表 | LoreAI',
@@ -30,13 +32,7 @@ export default function GlossaryPageZh() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '常见问题', href: '/zh/faq' },
-            { label: '术语表', href: '/zh/glossary', active: true },
-            { label: '对比', href: '/zh/compare' },
-          ]}
+          navItems={getNavItems('zh', '/zh/glossary')}
           langSwitchHref="/en/glossary"
         />
 
@@ -82,10 +78,7 @@ export default function GlossaryPageZh() {
           ))
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>AI 驱动 · 为人而建</p>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/newsletter/[date]/page.tsx
+++ b/src/app/zh/newsletter/[date]/page.tsx
@@ -5,6 +5,8 @@ import { notFound } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 async function getNewsletterContent(date: string): Promise<string | null> {
   try {
@@ -71,10 +73,7 @@ export default async function NewsletterZHDatePage({ params }: { params: Promise
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: '每日简报', href: '/zh/newsletter', active: true },
-            { label: '博客', href: '/zh/blog' },
-          ]}
+          navItems={getNavItems('zh', '/zh/newsletter')}
           langSwitchHref={langSwitchHref}
         />
 
@@ -113,12 +112,7 @@ export default async function NewsletterZHDatePage({ params }: { params: Promise
           </ReactMarkdown>
         </article>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '48px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <Link href="/zh/newsletter" style={{ color: '#8b5cf6', fontSize: '14px', textDecoration: 'none' }}>
-            ← 查看所有简报
-          </Link>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/newsletter/page.tsx
+++ b/src/app/zh/newsletter/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link'
 import fs from 'fs'
 import path from 'path'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 interface NewsletterEntry {
   date: string
@@ -82,10 +84,7 @@ export default async function NewsletterZHPage() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: '每日简报', href: '/zh/newsletter', active: true },
-            { label: '博客', href: '/zh/blog' },
-          ]}
+          navItems={getNavItems('zh', '/zh/newsletter')}
           langSwitchHref="/newsletter"
         />
 
@@ -150,10 +149,7 @@ export default async function NewsletterZHPage() {
           </form>
         </div>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '32px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>AI 精选 · 每日更新</p>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/resources/page.tsx
+++ b/src/app/zh/resources/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getBlogPosts } from '@/lib/blog'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 function formatDate(dateStr: string): string {
   const date = new Date(dateStr + 'T00:00:00')
@@ -25,11 +27,7 @@ export default async function ResourcesPageZh() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '资源', href: '/zh/resources', active: true },
-          ]}
+          navItems={getNavItems('zh', '/zh/resources')}
           langSwitchHref="/en/resources"
         />
 
@@ -112,10 +110,7 @@ export default async function ResourcesPageZh() {
           </Link>
         </div>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>AI 驱动 · 为人而建</p>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/timeline/[topic]/page.tsx
+++ b/src/app/zh/timeline/[topic]/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import { getAllTimelines, getTimeline, groupByDate, generateTimelineJsonLd } from '@/lib/timeline'
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
@@ -48,12 +50,7 @@ export default async function TimelineDetailZh({ params }: Props) {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '话题', href: '/zh/topics' },
-            { label: '时间线', href: '/zh/timeline', active: true },
-          ]}
+          navItems={getNavItems('zh', '/zh/timeline')}
           langSwitchHref={`/en/timeline/${topic}`}
         />
 
@@ -140,10 +137,7 @@ export default async function TimelineDetailZh({ params }: Props) {
           </Link>
         </div>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '48px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>AI 策展 · 为人而建</p>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/timeline/page.tsx
+++ b/src/app/zh/timeline/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import { getAllTimelines } from '@/lib/timeline'
 
 export const metadata = {
@@ -21,12 +23,7 @@ export default function TimelineIndexZh() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '话题', href: '/zh/topics' },
-            { label: '时间线', href: '/zh/timeline', active: true },
-          ]}
+          navItems={getNavItems('zh', '/zh/timeline')}
           langSwitchHref="/en/timeline"
         />
 
@@ -73,10 +70,7 @@ export default function TimelineIndexZh() {
           </div>
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>AI 策展 · 为人而建</p>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/topics/[topic]/page.tsx
+++ b/src/app/zh/topics/[topic]/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import { getTopicClusters, getTopicClusterContent } from '@/lib/topic-cluster'
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
@@ -84,11 +86,7 @@ export default async function TopicHubPageZh({ params }: Props) {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '话题', href: '/zh/topics', active: true },
-          ]}
+          navItems={getNavItems('zh', '/zh/topics')}
           langSwitchHref={`/en/topics/${topic}`}
         />
 
@@ -188,10 +186,7 @@ export default async function TopicHubPageZh({ params }: Props) {
           </Link>
         </div>
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '48px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>AI 策展 · 为人而建</p>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/app/zh/topics/page.tsx
+++ b/src/app/zh/topics/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 import { getAllTopicClustersWithCounts } from '@/lib/topic-cluster'
 
 export const metadata = {
@@ -21,11 +23,7 @@ export default async function TopicsPageZh() {
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
         <Header
           lang="zh"
-          navItems={[
-            { label: 'Newsletter', href: '/zh/newsletter' },
-            { label: '博客', href: '/zh/blog' },
-            { label: '话题', href: '/zh/topics', active: true },
-          ]}
+          navItems={getNavItems('zh', '/zh/topics')}
           langSwitchHref="/en/topics"
         />
 
@@ -72,10 +70,7 @@ export default async function TopicsPageZh() {
           </div>
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>AI 策展 · 为人而建</p>
-        </footer>
+        <Footer lang="zh" />
       </div>
     </main>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+
+interface FooterProps {
+  lang: 'en' | 'zh'
+}
+
+/**
+ * Shared site footer with consistent links and bilingual tagline.
+ */
+export default function Footer({ lang }: FooterProps) {
+  const isEn = lang === 'en'
+
+  return (
+    <footer className="mt-16 pt-6 border-t border-gray-100 text-center">
+      <p className="text-gray-400 text-[13px] mb-3">
+        {isEn ? 'Curated by AI \u00b7 Built for humans' : 'AI \u7b56\u5c55 \u00b7 \u4e3a\u4eba\u800c\u5efa'}
+      </p>
+      <div className="flex justify-center gap-4 text-sm">
+        <Link href={isEn ? '/newsletter' : '/zh/newsletter'} className="link-blue">
+          Newsletter
+        </Link>
+        <Link href={`/${lang}/blog`} className="link-blue">
+          {isEn ? 'Blog' : '\u535a\u5ba2'}
+        </Link>
+        <Link href={isEn ? '/en/faq' : '/zh/faq'} className="link-blue">
+          {isEn ? 'FAQ' : '\u5e38\u89c1\u95ee\u9898'}
+        </Link>
+        <Link href={isEn ? '/en/glossary' : '/zh/glossary'} className="link-blue">
+          {isEn ? 'Glossary' : '\u672f\u8bed\u8868'}
+        </Link>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useState } from 'react'
 import Link from 'next/link'
 
 export type NavItem = {
@@ -16,31 +19,90 @@ interface HeaderProps {
 
 /**
  * Shared site header with logo, navigation, and language switcher.
- * Used across all pages to avoid duplicating header markup.
+ * Responsive: hamburger menu on mobile, horizontal nav on desktop.
  */
 export default function Header({ lang, navItems, langSwitchHref }: HeaderProps) {
+  const [mobileOpen, setMobileOpen] = useState(false)
   const isEn = lang === 'en'
   const homeHref = isEn ? '/newsletter' : '/zh/newsletter'
 
   return (
-    <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '48px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '32px' }}>
-        <Link href={homeHref} style={{ textDecoration: 'none' }}>
-          <span style={{ fontSize: '20px', fontWeight: '800', color: '#2563eb', letterSpacing: '-0.02em' }}>
+    <header className="site-header sticky top-0 z-50 bg-white/90 backdrop-blur-md border-b border-transparent">
+      <div className="flex items-center justify-between py-4">
+        {/* Logo + Desktop Nav */}
+        <div className="flex items-center gap-8">
+          <Link href={homeHref} className="text-xl font-extrabold text-blue-600 tracking-tight no-underline">
             LoreAI
-          </span>
-        </Link>
-        <nav style={{ display: 'flex', gap: '24px', fontSize: '14px' }}>
+          </Link>
+          <nav className="hidden md:flex gap-6 text-sm">
+            {navItems.map((item) =>
+              item.active ? (
+                <span
+                  key={item.label}
+                  className="text-gray-900 font-semibold border-b-2 border-purple-500 pb-1"
+                >
+                  {item.label}
+                </span>
+              ) : (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  className="text-gray-500 hover:text-gray-900 no-underline pb-1 transition-colors"
+                >
+                  {item.label}
+                </Link>
+              )
+            )}
+          </nav>
+        </div>
+
+        {/* Language Switcher + Mobile Toggle */}
+        <div className="flex items-center gap-4">
+          {/* Language Switcher */}
+          <div className="flex gap-2 text-[13px]">
+            {isEn ? (
+              <>
+                <span className="text-gray-900 font-medium">EN</span>
+                <span className="text-gray-300">|</span>
+                <Link href={langSwitchHref} className="text-gray-500 no-underline hover:text-gray-900 transition-colors">
+                  中文
+                </Link>
+              </>
+            ) : (
+              <>
+                <Link href={langSwitchHref} className="text-gray-500 no-underline hover:text-gray-900 transition-colors">
+                  EN
+                </Link>
+                <span className="text-gray-300">|</span>
+                <span className="text-gray-900 font-medium">中文</span>
+              </>
+            )}
+          </div>
+
+          {/* Hamburger Button (mobile only) */}
+          <button
+            className="md:hidden flex flex-col justify-center items-center w-8 h-8 gap-1.5"
+            onClick={() => setMobileOpen(!mobileOpen)}
+            aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+            aria-expanded={mobileOpen}
+          >
+            <span className={`block w-5 h-0.5 bg-gray-700 transition-transform duration-200 ${mobileOpen ? 'rotate-45 translate-y-[4px]' : ''}`} />
+            <span className={`block w-5 h-0.5 bg-gray-700 transition-opacity duration-200 ${mobileOpen ? 'opacity-0' : ''}`} />
+            <span className={`block w-5 h-0.5 bg-gray-700 transition-transform duration-200 ${mobileOpen ? '-rotate-45 -translate-y-[4px]' : ''}`} />
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile Nav Drawer */}
+      <div
+        className={`md:hidden overflow-hidden transition-all duration-200 ease-in-out ${mobileOpen ? 'max-h-96 pb-4' : 'max-h-0'}`}
+      >
+        <nav className="flex flex-col gap-1 border-t border-gray-100 pt-3">
           {navItems.map((item) =>
             item.active ? (
               <span
                 key={item.label}
-                style={{
-                  color: '#111827',
-                  fontWeight: '600',
-                  borderBottom: '2px solid #8b5cf6',
-                  paddingBottom: '4px',
-                }}
+                className="text-gray-900 font-semibold text-sm py-2 px-3 rounded-lg bg-purple-50 border-l-2 border-purple-500"
               >
                 {item.label}
               </span>
@@ -48,32 +110,14 @@ export default function Header({ lang, navItems, langSwitchHref }: HeaderProps) 
               <Link
                 key={item.label}
                 href={item.href}
-                style={{ color: '#6b7280', textDecoration: 'none', paddingBottom: '4px' }}
+                className="text-gray-500 hover:text-gray-900 hover:bg-gray-50 text-sm py-2 px-3 rounded-lg no-underline transition-colors"
+                onClick={() => setMobileOpen(false)}
               >
                 {item.label}
               </Link>
             )
           )}
         </nav>
-      </div>
-      <div style={{ display: 'flex', gap: '8px', fontSize: '13px' }}>
-        {isEn ? (
-          <>
-            <span style={{ color: '#111827', fontWeight: '500' }}>EN</span>
-            <span style={{ color: '#d1d5db' }}>|</span>
-            <Link href={langSwitchHref} style={{ color: '#6b7280', textDecoration: 'none' }}>
-              中文
-            </Link>
-          </>
-        ) : (
-          <>
-            <Link href={langSwitchHref} style={{ color: '#6b7280', textDecoration: 'none' }}>
-              EN
-            </Link>
-            <span style={{ color: '#d1d5db' }}>|</span>
-            <span style={{ color: '#111827', fontWeight: '500' }}>中文</span>
-          </>
-        )}
       </div>
     </header>
   )

--- a/src/components/pages/BlogDetailPage.tsx
+++ b/src/components/pages/BlogDetailPage.tsx
@@ -3,7 +3,9 @@ import Link from 'next/link'
 import { getBlogPost } from '@/lib/blog'
 import { getRelatedContent, type RelatedItem } from '@/lib/related-content'
 import { getTopicClusters, type TopicCluster } from '@/lib/topic-cluster'
+import { getNavItems } from '@/lib/nav'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
 import TableOfContents from '@/components/TableOfContents'
 import MermaidContent from '@/components/MermaidContent'
 
@@ -73,10 +75,7 @@ export default async function BlogDetailPage({ lang, slug }: BlogDetailPageProps
     ? (post.hreflang_zh || '/zh/blog')
     : (post.hreflang_en || '/en/blog')
 
-  const navItems = [
-    { label: 'Newsletter', href: isEn ? '/newsletter' : '/zh/newsletter' },
-    { label: isEn ? 'Blog' : '博客', href: `/${lang}/blog`, active: true },
-  ]
+  const navItems = getNavItems(lang, `/${lang}/blog`)
 
   return (
     <main className="min-h-screen bg-white">
@@ -210,23 +209,7 @@ export default async function BlogDetailPage({ lang, slug }: BlogDetailPageProps
             </Link>
           </div>
 
-          {/* Footer */}
-          <footer className="mt-16 pt-8 border-t border-gray-100 text-center">
-            <p className="text-muted text-sm mb-2">
-              {isEn ? 'Curated by AI, built for humans' : 'AI 策展，为人而建'}
-            </p>
-            <div className="flex justify-center gap-4 text-sm">
-              <Link href={isEn ? '/' : '/zh'} className="link-blue">
-                {isEn ? 'Home' : '首页'}
-              </Link>
-              <Link href={isEn ? '/newsletter' : '/zh/newsletter'} className="link-blue">
-                Newsletter
-              </Link>
-              <Link href={`/${lang}/blog`} className="link-blue">
-                {isEn ? 'Blog' : '博客'}
-              </Link>
-            </div>
-          </footer>
+          <Footer lang={lang} />
         </div>
       </div>
     </main>

--- a/src/components/pages/BlogListPage.tsx
+++ b/src/components/pages/BlogListPage.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getBlogPosts } from '@/lib/blog'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { getNavItems } from '@/lib/nav'
 
 const tierConfigEn = {
   1: { label: '🔬 Deep Dive', color: '#7c3aed', bg: '#f5f3ff' },
@@ -44,10 +46,7 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
   const tier2Posts = posts.filter(p => p.tier === 2)
   const tier3Posts = posts.filter(p => p.tier === 3)
 
-  const navItems = [
-    { label: isEn ? 'Newsletter' : 'Newsletter', href: isEn ? '/newsletter' : '/zh/newsletter' },
-    { label: isEn ? 'Blog' : '博客', href: `/${lang}/blog`, active: true },
-  ]
+  const navItems = getNavItems(lang, `/${lang}/blog`)
 
   const allPosts = [...tier1Posts, ...tier2Posts, ...tier3Posts]
   const itemListLd = {
@@ -63,8 +62,8 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
   }
 
   return (
-    <main style={{ minHeight: '100vh', backgroundColor: '#ffffff' }}>
-      <div style={{ maxWidth: '800px', margin: '0 auto', padding: '32px 24px' }}>
+    <main className="min-h-screen bg-white">
+      <div className="max-w-[800px] mx-auto px-6 py-8">
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
@@ -76,29 +75,29 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
         />
 
         {/* Hero */}
-        <div style={{ marginBottom: '40px' }}>
-          <h1 style={{ fontSize: '28px', fontWeight: 'bold', background: 'linear-gradient(to right, #ec4899, #a855f7, #6366f1)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent', marginBottom: '8px' }}>
+        <div className="mb-10">
+          <h1 className="text-[28px] font-bold bg-gradient-to-r from-pink-500 via-purple-500 to-indigo-500 bg-clip-text text-transparent mb-2">
             {isEn ? 'Blog' : '博客'}
           </h1>
-          <p style={{ color: '#6b7280', fontSize: '16px' }}>
+          <p className="text-gray-500 text-base">
             {isEn ? 'Deep dives, tutorials, and insights' : '深度解读、教程和洞察'}
           </p>
         </div>
 
         {/* Divider */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '40px' }}>
-          <div style={{ height: '8px', width: '120px', background: 'linear-gradient(90deg, #EC4899, #8B5CF6, #3B82F6)', borderRadius: '2px' }} />
-          <div style={{ width: '8px', height: '8px', backgroundColor: '#60A5FA', borderRadius: '2px' }} />
-          <div style={{ width: '8px', height: '8px', backgroundColor: '#93C5FD', borderRadius: '2px', opacity: 0.7 }} />
+        <div className="flex items-center gap-1 mb-10">
+          <div className="h-2 w-[120px] bg-gradient-to-r from-pink-500 via-purple-500 to-blue-500 rounded-sm" />
+          <div className="w-2 h-2 bg-blue-400 rounded-sm" />
+          <div className="w-2 h-2 bg-blue-300 rounded-sm opacity-70" />
         </div>
 
         {/* Posts */}
         {posts.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '64px 0' }}>
-            <p style={{ color: '#6b7280', fontSize: '16px', marginBottom: '8px' }}>
+          <div className="text-center py-16">
+            <p className="text-gray-500 text-base mb-2">
               {isEn ? 'No posts yet' : '暂无文章'}
             </p>
-            <p style={{ color: '#9ca3af', fontSize: '14px' }}>
+            <p className="text-gray-400 text-sm">
               {isEn ? 'Check back soon!' : '敬请期待！'}
             </p>
           </div>
@@ -106,7 +105,7 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
           <>
             {/* Featured / Tier 1 */}
             {tier1Posts.length > 0 && (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', marginBottom: '48px' }}>
+              <div className="flex flex-col gap-4 mb-12">
                 {tier1Posts.map((post) => {
                   const tier = tierConfig[1]
                   let dateLabel: string
@@ -121,16 +120,25 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
                   const descLimit = isEn ? 200 : 150
 
                   return (
-                    <Link key={post.slug} href={`/${lang}/blog/${post.slug}`} style={{ display: 'block', textDecoration: 'none', padding: '24px', borderRadius: '12px', border: '2px solid #e9d5ff', backgroundColor: '#faf5ff', transition: 'box-shadow 0.2s' }} className="blog-card">
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '12px', flexWrap: 'wrap' }}>
-                        <span style={{ fontSize: '11px', fontWeight: '600', color: tier.color, backgroundColor: tier.bg, padding: '2px 8px', borderRadius: '4px' }}>{tier.label}</span>
-                        <span style={{ fontSize: '12px', color: '#9ca3af' }}>{dateLabel}</span>
-                        <span style={{ fontSize: '12px', color: '#d1d5db' }}>·</span>
-                        <span style={{ fontSize: '12px', color: '#9ca3af' }}>{readTimeLabel}</span>
+                    <Link
+                      key={post.slug}
+                      href={`/${lang}/blog/${post.slug}`}
+                      className="block no-underline p-6 rounded-xl border-2 border-purple-200 bg-purple-50 hover:shadow-md transition-shadow"
+                    >
+                      <div className="flex items-center gap-2 mb-3 flex-wrap">
+                        <span
+                          className="text-[11px] font-semibold px-2 py-0.5 rounded"
+                          style={{ color: tier.color, backgroundColor: tier.bg }}
+                        >
+                          {tier.label}
+                        </span>
+                        <span className="text-xs text-gray-400">{dateLabel}</span>
+                        <span className="text-xs text-gray-300">&middot;</span>
+                        <span className="text-xs text-gray-400">{readTimeLabel}</span>
                       </div>
-                      <h2 style={{ fontSize: '18px', fontWeight: '600', color: '#111827', marginBottom: '4px', lineHeight: '1.4' }}>{post.title}</h2>
+                      <h2 className="text-lg font-semibold text-gray-900 mb-1 leading-snug">{post.title}</h2>
                       {post.description && (
-                        <p style={{ fontSize: '13px', color: '#6b7280', lineHeight: '1.5', marginTop: '4px' }}>
+                        <p className="text-[13px] text-gray-500 leading-relaxed mt-1">
                           {post.description.length > descLimit ? post.description.slice(0, descLimit) + '...' : post.description}
                         </p>
                       )}
@@ -142,12 +150,12 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
 
             {/* Analysis / Tier 2 */}
             {tier2Posts.length > 0 && (
-              <div style={{ marginBottom: '48px' }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '16px' }}>
-                  <h2 style={{ fontSize: '18px', fontWeight: '600', color: '#2563eb' }}>{isEn ? '📝 Analysis' : '📝 分析'}</h2>
-                  <span style={{ fontSize: '12px', color: '#9ca3af' }}>({tier2Posts.length})</span>
+              <div className="mb-12">
+                <div className="flex items-center gap-2 mb-4">
+                  <h2 className="text-lg font-semibold text-blue-600">{isEn ? '📝 Analysis' : '📝 分析'}</h2>
+                  <span className="text-xs text-gray-400">({tier2Posts.length})</span>
                 </div>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                <div className="flex flex-col gap-2.5">
                   {tier2Posts.map((post) => {
                     const tier = tierConfig[2]
                     let dateLabel: string
@@ -162,16 +170,25 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
                     const descLimit = isEn ? 100 : 80
 
                     return (
-                      <Link key={post.slug} href={`/${lang}/blog/${post.slug}`} style={{ display: 'block', textDecoration: 'none', padding: '16px 20px', borderRadius: '12px', border: '1px solid #f3f4f6', backgroundColor: '#ffffff', transition: 'box-shadow 0.2s' }} className="blog-card">
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px', flexWrap: 'wrap' }}>
-                          <span style={{ fontSize: '11px', fontWeight: '600', color: tier.color, backgroundColor: tier.bg, padding: '2px 8px', borderRadius: '4px' }}>{tier.label}</span>
-                          <span style={{ fontSize: '12px', color: '#9ca3af' }}>{dateLabel}</span>
-                          <span style={{ fontSize: '12px', color: '#d1d5db' }}>·</span>
-                          <span style={{ fontSize: '12px', color: '#9ca3af' }}>{readTimeLabel}</span>
+                      <Link
+                        key={post.slug}
+                        href={`/${lang}/blog/${post.slug}`}
+                        className="block no-underline px-5 py-4 rounded-xl border border-gray-100 bg-white hover:shadow-md transition-shadow"
+                      >
+                        <div className="flex items-center gap-2 mb-1.5 flex-wrap">
+                          <span
+                            className="text-[11px] font-semibold px-2 py-0.5 rounded"
+                            style={{ color: tier.color, backgroundColor: tier.bg }}
+                          >
+                            {tier.label}
+                          </span>
+                          <span className="text-xs text-gray-400">{dateLabel}</span>
+                          <span className="text-xs text-gray-300">&middot;</span>
+                          <span className="text-xs text-gray-400">{readTimeLabel}</span>
                         </div>
-                        <h2 style={{ fontSize: '15px', fontWeight: '500', color: '#111827', marginBottom: '4px', lineHeight: '1.4' }}>{post.title}</h2>
+                        <h2 className="text-[15px] font-medium text-gray-900 mb-1 leading-snug">{post.title}</h2>
                         {post.description && (
-                          <p style={{ fontSize: '13px', color: '#6b7280', lineHeight: '1.5', marginTop: '4px' }}>
+                          <p className="text-[13px] text-gray-500 leading-relaxed mt-1">
                             {post.description.length > descLimit ? post.description.slice(0, descLimit) + '...' : post.description}
                           </p>
                         )}
@@ -184,12 +201,12 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
 
             {/* Quick Read / Tier 3 */}
             {tier3Posts.length > 0 && (
-              <div style={{ marginBottom: '16px' }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '16px' }}>
-                  <h2 style={{ fontSize: '18px', fontWeight: '600', color: '#059669' }}>{isEn ? '⚡ Quick Read' : '⚡ 快读'}</h2>
-                  <span style={{ fontSize: '12px', color: '#9ca3af' }}>({tier3Posts.length})</span>
+              <div className="mb-4">
+                <div className="flex items-center gap-2 mb-4">
+                  <h2 className="text-lg font-semibold text-emerald-600">{isEn ? '⚡ Quick Read' : '⚡ 快读'}</h2>
+                  <span className="text-xs text-gray-400">({tier3Posts.length})</span>
                 </div>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                <div className="flex flex-col gap-2.5">
                   {tier3Posts.map((post) => {
                     const tier = tierConfig[3]
                     let dateLabel: string
@@ -204,16 +221,25 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
                     const descLimit = isEn ? 100 : 80
 
                     return (
-                      <Link key={post.slug} href={`/${lang}/blog/${post.slug}`} style={{ display: 'block', textDecoration: 'none', padding: '16px 20px', borderRadius: '12px', border: '1px solid #f3f4f6', backgroundColor: '#ffffff', transition: 'box-shadow 0.2s' }} className="blog-card">
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px', flexWrap: 'wrap' }}>
-                          <span style={{ fontSize: '11px', fontWeight: '600', color: tier.color, backgroundColor: tier.bg, padding: '2px 8px', borderRadius: '4px' }}>{tier.label}</span>
-                          <span style={{ fontSize: '12px', color: '#9ca3af' }}>{dateLabel}</span>
-                          <span style={{ fontSize: '12px', color: '#d1d5db' }}>·</span>
-                          <span style={{ fontSize: '12px', color: '#9ca3af' }}>{readTimeLabel}</span>
+                      <Link
+                        key={post.slug}
+                        href={`/${lang}/blog/${post.slug}`}
+                        className="block no-underline px-5 py-4 rounded-xl border border-gray-100 bg-white hover:shadow-md transition-shadow"
+                      >
+                        <div className="flex items-center gap-2 mb-1.5 flex-wrap">
+                          <span
+                            className="text-[11px] font-semibold px-2 py-0.5 rounded"
+                            style={{ color: tier.color, backgroundColor: tier.bg }}
+                          >
+                            {tier.label}
+                          </span>
+                          <span className="text-xs text-gray-400">{dateLabel}</span>
+                          <span className="text-xs text-gray-300">&middot;</span>
+                          <span className="text-xs text-gray-400">{readTimeLabel}</span>
                         </div>
-                        <h2 style={{ fontSize: '15px', fontWeight: '500', color: '#111827', marginBottom: '4px', lineHeight: '1.4' }}>{post.title}</h2>
+                        <h2 className="text-[15px] font-medium text-gray-900 mb-1 leading-snug">{post.title}</h2>
                         {post.description && (
-                          <p style={{ fontSize: '13px', color: '#6b7280', lineHeight: '1.5', marginTop: '4px' }}>
+                          <p className="text-[13px] text-gray-500 leading-relaxed mt-1">
                             {post.description.length > descLimit ? post.description.slice(0, descLimit) + '...' : post.description}
                           </p>
                         )}
@@ -226,12 +252,7 @@ export default async function BlogListPage({ lang }: BlogListPageProps) {
           </>
         )}
 
-        {/* Footer */}
-        <footer style={{ textAlign: 'center', marginTop: '64px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
-          <p style={{ color: '#9ca3af', fontSize: '13px' }}>
-            {isEn ? 'Curated by AI · Built for humans' : 'AI 驱动 · 为人而建'}
-          </p>
-        </footer>
+        <Footer lang={lang} />
       </div>
     </main>
   )

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,0 +1,46 @@
+import type { NavItem } from '@/components/Header'
+
+/**
+ * Standard navigation items for the site.
+ * Returns a consistent set of nav links with the active item auto-detected from the path.
+ */
+export function getNavItems(lang: 'en' | 'zh', activePath: string): NavItem[] {
+  const isEn = lang === 'en'
+  const prefix = isEn ? '' : '/zh'
+
+  const items: NavItem[] = [
+    {
+      label: 'Newsletter',
+      href: isEn ? '/newsletter' : '/zh/newsletter',
+    },
+    {
+      label: isEn ? 'Blog' : '博客',
+      href: `/${lang}/blog`,
+    },
+    {
+      label: isEn ? 'FAQ' : '常见问题',
+      href: `${prefix || '/en'}/faq`,
+    },
+    {
+      label: isEn ? 'Glossary' : '术语表',
+      href: `${prefix || '/en'}/glossary`,
+    },
+    {
+      label: isEn ? 'Compare' : '对比',
+      href: `${prefix || '/en'}/compare`,
+    },
+    {
+      label: isEn ? 'Topics' : '话题',
+      href: `${prefix || '/en'}/topics`,
+    },
+  ]
+
+  // Auto-detect active item based on path
+  for (const item of items) {
+    if (activePath === item.href || activePath.startsWith(item.href + '/')) {
+      item.active = true
+    }
+  }
+
+  return items
+}


### PR DESCRIPTION
## Summary
- **Mobile-responsive Header**: Rewrote `Header.tsx` as client component with hamburger menu (slide-down drawer on <768px), sticky positioning with glass blur effect, all inline styles replaced with Tailwind
- **Shared navigation**: Created `src/lib/nav.ts` with `getNavItems(lang, activePath)` — consistent 6-item nav (Newsletter | Blog | FAQ | Glossary | Compare | Topics) across all 35 page files, replacing per-page inline arrays
- **Shared Footer**: Created `src/components/Footer.tsx` with bilingual tagline and nav links, replacing ~30 duplicated inline `<footer>` blocks
- **BlogListPage Tailwind migration**: Converted all inline `style={{}}` to Tailwind utility classes, matching `BlogDetailPage.tsx` patterns
- **Sticky header adjustments**: Updated TOC sidebar offset to account for sticky header height

## Test plan
- [x] `npm run build` passes (all static pages generated)
- [x] `npm run test:unit` — 145/154 passed (9 pre-existing content failures, unchanged from baseline)
- [ ] Manual responsive check: 320px → 768px → 1440px
- [ ] Verify hamburger menu opens/closes on mobile
- [ ] Both `/en/` and `/zh/` paths render correct nav labels
- [ ] Sticky header stays visible on long article scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)